### PR TITLE
sftpserver: Support some extended submessages for added functionality

### DIFF
--- a/include/libssh/sftp.h
+++ b/include/libssh/sftp.h
@@ -123,6 +123,7 @@ struct sftp_client_message_struct {
     sftp_session sftp;
     uint8_t type;
     uint32_t id;
+    char *submessage; /* for extended messages */
     char *filename; /* can be "path" */
     uint32_t flags;
     sftp_attributes attr;
@@ -862,6 +863,7 @@ LIBSSH_API const char *sftp_client_message_get_filename(sftp_client_message msg)
 LIBSSH_API void sftp_client_message_set_filename(sftp_client_message msg, const char *newname);
 LIBSSH_API const char *sftp_client_message_get_data(sftp_client_message msg);
 LIBSSH_API uint32_t sftp_client_message_get_flags(sftp_client_message msg);
+LIBSSH_API const char *sftp_client_message_get_submessage(sftp_client_message msg);
 LIBSSH_API int sftp_send_client_message(sftp_session sftp, sftp_client_message msg);
 LIBSSH_API int sftp_reply_name(sftp_client_message msg, const char *name,
     sftp_attributes attr);
@@ -1011,6 +1013,7 @@ LIBSSH_API void sftp_handle_remove(sftp_session sftp, void *handle);
 #define SFTP_RENAME SSH_FXP_RENAME
 #define SFTP_READLINK SSH_FXP_READLINK
 #define SFTP_SYMLINK SSH_FXP_SYMLINK
+#define SFTP_EXTENDED SSH_FXP_EXTENDED
 
 /* openssh flags */
 #define SSH_FXE_STATVFS_ST_RDONLY 0x1 /* read-only */

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -219,7 +219,12 @@ int sftp_server_init(sftp_session sftp){
     return -1;
   }
 
-  if (ssh_buffer_add_u32(reply, ntohl(LIBSFTP_VERSION)) < 0) {
+  if (ssh_buffer_pack(reply, "dssss",
+                      ntohl(LIBSFTP_VERSION),
+                      "posix-rename@openssh.com",
+                      "1",
+                      "hardlink@openssh.com",
+                      "1") < 0) {
     ssh_set_error_oom(session);
     ssh_buffer_free(reply);
     return -1;


### PR DESCRIPTION
Support "hardlink@openssh.com" and "posix-rename@openssh.com" submessages.

This is not a complete implementation of all extended submessages.  The following are the ones missing:

"statvfs@openssh.com"
"fstatvfs@openssh.com"
"fsync@openssh.com"

I left these out for now since our implementation does not need these.  However, if we plan on trying to upstream this, we should consider implementing them.